### PR TITLE
Fix path not found

### DIFF
--- a/vars/acnMavenBuildandCodeAnalysis.groovy
+++ b/vars/acnMavenBuildandCodeAnalysis.groovy
@@ -29,6 +29,6 @@ def call(body) {
                 "-Dsonar.tests=src/test/ "+
                 "-Dsonar.test.inclusions=**/*test*/**,**/*Test*/**,**/*Test*.java "+
                 "-Dsonar.exclusions=**/*test*/**,**/*Test*/**,**/*Test*.java "+
-                "-Dsonar.java.binaries=target/classes"
+                "-Dsonar.java.binaries=."
              }
   } // End Function


### PR DESCRIPTION
Found error 
[ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.4.0.905:sonar (default-cli) on project fund-out-service: No files nor directories matching 'target/classes' -> [Help 1]

This post recommend to set binary path --> https://stackoverflow.com/questions/45781904/sonarqube-upgrade-from-6-4-to-6-5-breaks-the-scanner